### PR TITLE
ropon is now usable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+python-dotenv

--- a/usage.py
+++ b/usage.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.insert(0, "src")
 from ropon.apis.players.game import PlayerGamesCreation
 from ropon.apis.players.info import Player
 from ropon.apis.players.avatar import PlayerOutfit


### PR DESCRIPTION
usage.py now points to src
python-dotenv was missing from requirements since usage was using it